### PR TITLE
Add flag, environment var to report times in UTC

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -24,5 +24,7 @@ are recognized:
 
   shortfile: Include the filename and line number in all log messages.
   Overrides longfile.
+
+  UTC: Report timestamps in UTC instead of the local time zone.
 */
 package slog

--- a/log.go
+++ b/log.go
@@ -60,6 +60,10 @@ const (
 	// Lshortfile modifies the logger output to include filename and line number
 	// of the logging callsite, e.g. main.go:123.  Overrides Llongfile.
 	Lshortfile
+
+	// LUTC modifies the logger output to report all times in UTC instead of
+	// in the local time zone.
+	LUTC
 )
 
 // Read logger flags from the LOGFLAGS environment variable.  Multiple flags can
@@ -71,6 +75,8 @@ func init() {
 			defaultFlags |= Llongfile
 		case "shortfile":
 			defaultFlags |= Lshortfile
+		case "UTC":
+			defaultFlags |= LUTC
 		}
 	}
 }
@@ -265,6 +271,9 @@ func callsite(flag uint32) (string, int) {
 // rules.
 func (b *Backend) print(lvl, tag string, args ...interface{}) {
 	t := time.Now() // get as early as possible
+	if b.flag&LUTC != 0 {
+		t = t.UTC()
+	}
 
 	bytebuf := buffer()
 
@@ -292,6 +301,9 @@ func (b *Backend) print(lvl, tag string, args ...interface{}) {
 // specifier.
 func (b *Backend) printf(lvl, tag string, format string, args ...interface{}) {
 	t := time.Now() // get as early as possible
+	if b.flag&LUTC != 0 {
+		t = t.UTC()
+	}
 
 	bytebuf := buffer()
 


### PR DESCRIPTION
If a logger is created with the slog.LUTC flag, or the LOGFLAGS
environment variable specifies the option UTC, report all timestamps
in the log output in UTC rather than using the local time zone.